### PR TITLE
Allow me to exclude from default_config

### DIFF
--- a/homeassistant/bootstrap.py
+++ b/homeassistant/bootstrap.py
@@ -553,6 +553,15 @@ async def _async_set_up_integrations(
             ).values()
             if isinstance(int_or_exc, loader.Integration)
         ]
+
+        for integration in integrations_to_process:
+            for integration_in_config in config:
+                if "exclude" in config[integration_in_config]:
+                    for ignored_integration in config[integration_in_config]["exclude"]:
+                        if ignored_integration == integration.domain:
+                            integrations_to_process.remove(integration)
+                            break
+
         resolve_dependencies_tasks = [
             itg.resolve_dependencies()
             for itg in integrations_to_process


### PR DESCRIPTION
- Python isn't my native language so there are some glaring inefficiencies in this implementation. I'm ignoring that because this only runs once on server load, so.. meh.

- This allows you to add "exclude" to any of the integrations in the config and will prevent that named integration from loading. There are some caveats to how this is implemented that could cause some confusion but I do not think it will in the real world usage. That's because if you're using "default_config", your config is probably pretty simple and terse.

In the config, we can now:

```yaml
default_config:
  exclude:
    - map
    - energy

```
